### PR TITLE
Make compilation faster and less demanding

### DIFF
--- a/lib/email_guard/list.ex
+++ b/lib/email_guard/list.ex
@@ -12,16 +12,13 @@ defmodule EmailGuard.List do
     filename = opts[:filename] || raise(ArgumentError, message: "expected :filename")
 
     quote bind_quoted: [filepath: path_to_list(filename)] do
-      filepath
-      |> File.stream!()
-      |> Stream.map(&String.trim/1)
-      |> Stream.reject(&match?("", &1))
-      |> Enum.uniq()
-      |> Enum.map(fn domain ->
-        def lookup(unquote(domain)), do: __MODULE__
-      end)
+      @list filepath
+            |> File.stream!()
+            |> Stream.map(&String.trim/1)
+            |> Stream.reject(&match?("", &1))
+            |> Enum.into(%MapSet{})
 
-      def lookup(_unmatched_domain), do: nil
+      def lookup(domain), do: (MapSet.member?(@list, domain) && __MODULE__) || nil
     end
   end
 


### PR DESCRIPTION
Currently, the compilation of this dependency takes about a minute and consumes a lot of memory (we're talking about several GB here).

I'm proposing a MapSet to lookup a domain.

Compilation time before the change:
```
$ time mix compile
Compiling 4 files (.ex)
Compiling lib/email_guard/disposable_list.ex (it's taking more than 10s)
Generated email_guard app
mix compile  51.56s user 7.96s system 114% cpu 52.168 total
```

Compilation time after the change:
```
$ time mix compile                           
Compiling 4 files (.ex)
Generated email_guard app
mix compile  2.25s user 0.58s system 170% cpu 1.657 total
```

Benchmark results before the change:
```
MIX_ENV=bench mix run bench/check_bench.exs
Compiling 4 files (.ex)
Compiling lib/email_guard/disposable_list.ex (it's taking more than 10s)
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
Number of Available Cores: 8
Available memory: 8 GB
Elixir 1.11.2
Erlang 22.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 56 s

Benchmarking disposable found...
Benchmarking disposable passed...
Benchmarking free found...
Benchmarking free passed...

Name                        ips        average  deviation         median         99th %
disposable passed        1.39 M      721.27 ns  ±3495.20%         980 ns         980 ns
free found               1.33 M      751.35 ns  ±6145.11%         980 ns         980 ns
free passed              1.32 M      757.29 ns  ±3618.62%         980 ns        1980 ns
disposable found         1.18 M      848.07 ns  ±6759.64%         980 ns         980 ns

Comparison: 
disposable passed        1.39 M
free found               1.33 M - 1.04x slower +30.07 ns
free passed              1.32 M - 1.05x slower +36.02 ns
disposable found         1.18 M - 1.18x slower +126.79 ns

Memory usage statistics:

Name                 Memory usage
disposable passed           184 B
free found                  208 B - 1.13x memory usage +24 B
free passed                 184 B - 1.00x memory usage +0 B
disposable found            208 B - 1.13x memory usage +24 B

**All measurements for memory usage were the same**
```

Benchmark results after the change:
```
MIX_ENV=bench mix run bench/check_bench.exs
Compiling 4 files (.ex)
Operating System: macOS
CPU Information: Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz
Number of Available Cores: 8
Available memory: 8 GB
Elixir 1.11.2
Erlang 22.3

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: none specified
Estimated total run time: 56 s

Benchmarking disposable found...
Benchmarking disposable passed...
Benchmarking free found...
Benchmarking free passed...

Name                        ips        average  deviation         median         99th %
free passed              1.40 M      713.20 ns  ±5039.97%        1000 ns        1000 ns
disposable found         1.35 M      742.83 ns  ±4174.91%        1000 ns        1000 ns
free found               1.34 M      746.96 ns  ±4075.37%        1000 ns        1000 ns
disposable passed        1.34 M      747.00 ns  ±6441.88%        1000 ns        1000 ns

Comparison: 
free passed              1.40 M
disposable found         1.35 M - 1.04x slower +29.63 ns
free found               1.34 M - 1.05x slower +33.77 ns
disposable passed        1.34 M - 1.05x slower +33.80 ns

Memory usage statistics:

Name                 Memory usage
free passed                 144 B
disposable found            168 B - 1.17x memory usage +24 B
free found                  168 B - 1.17x memory usage +24 B
disposable passed           144 B - 1.00x memory usage +0 B

**All measurements for memory usage were the same**
```